### PR TITLE
Add legacy DAG

### DIFF
--- a/dags/atd_road_conditions_data_socrata.py
+++ b/dags/atd_road_conditions_data_socrata.py
@@ -45,10 +45,10 @@ with DAG(
         api_version="auto",
         auto_remove=True,
         command=f'./atd-road-conditions/socrata.py -d "{date_filter}"',
-        #docker_url="tcp://localhost:2376",
-        #network_mode="bridge",
+        #docker_url="tcp://localhost:2376",     # doesn't work locally, as set
+        #network_mode="bridge",                 # don't need
         environment=env_vars,
-        #tty=True,
+        #tty=True,                              # don't need
     )
 
     t1

--- a/dags/atd_road_conditions_data_socrata.py
+++ b/dags/atd_road_conditions_data_socrata.py
@@ -45,10 +45,10 @@ with DAG(
         api_version="auto",
         auto_remove=True,
         command=f'./atd-road-conditions/socrata.py -d "{date_filter}"',
-        #docker_url="tcp://localhost:2376",     # doesn't work locally, as set
-        #network_mode="bridge",                 # don't need
+        # docker_url="tcp://localhost:2376",     # doesn't work locally, as set
+        network_mode="bridge",                 # don't need
         environment=env_vars,
-        #tty=True,                              # don't need
+        tty=True,                              # don't need
     )
 
     t1

--- a/dags/atd_road_conditions_data_socrata.py
+++ b/dags/atd_road_conditions_data_socrata.py
@@ -45,7 +45,7 @@ with DAG(
         api_version="auto",
         auto_remove=True,
         command=f'./atd-road-conditions/socrata.py -d "{date_filter}"',
-        # docker_url="tcp://localhost:2376",     # doesn't work locally, as set
+        # docker_url="tcp://localhost:2376",   # doesn't work locally, as set
         network_mode="bridge",                 # don't need
         environment=env_vars,
         tty=True,                              # don't need

--- a/dags/atd_road_conditions_data_socrata.py
+++ b/dags/atd_road_conditions_data_socrata.py
@@ -46,9 +46,9 @@ with DAG(
         auto_remove=True,
         command=f'./atd-road-conditions/socrata.py -d "{date_filter}"',
         # docker_url="tcp://localhost:2376",   # doesn't work locally, as set
-        network_mode="bridge",                 # don't need
+        network_mode="bridge",                 # does this need the signal network?
         environment=env_vars,
-        tty=True,                              # don't need
+        tty=True,                              # unsure if this is needed
     )
 
     t1

--- a/dags/atd_road_conditions_data_socrata.py
+++ b/dags/atd_road_conditions_data_socrata.py
@@ -1,0 +1,57 @@
+from datetime import datetime, timedelta
+from airflow.models import DAG
+from airflow.models import Variable
+from airflow.operators.docker_operator import DockerOperator
+
+default_args = {
+    "owner": "airflow",
+    "description": "Fetch road condition sensor data from postgrest and publish to socrata ",  # noqa:E501
+    "depend_on_past": False,
+    "start_date": datetime(2020, 9, 1),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "retry_delay": timedelta(minutes=5),
+}
+
+docker_image = "atddocker/atd-road-conditions:production"
+
+
+# assemble env vars
+env_vars = Variable.get("atd_road_conditions_postgrest", deserialize_json=True)
+atd_knack_auth = Variable.get("atd_knack_auth", deserialize_json=True)
+env_vars["KNACK_APP_ID"] = atd_knack_auth["data-tracker"]["prod"]["app_id"]
+env_vars["KNACK_API_KEY"] = atd_knack_auth["data-tracker"]["prod"]["api_key"]
+env_vars["SOCRATA_API_KEY_ID"] = Variable.get("atd_service_bot_socrata_api_key_id")
+env_vars["SOCRATA_API_KEY_SECRET"] = Variable.get(
+    "atd_service_bot_socrata_api_key_secret"
+)
+env_vars["SOCRATA_APP_TOKEN"] = Variable.get("atd_service_bot_socrata_app_token")
+
+with DAG(
+    dag_id="road_conditions_socrata",
+    default_args=default_args,
+    schedule_interval="*/5 * * * *",
+    dagrun_timeout=timedelta(minutes=60),
+    tags=["production", "road-conditions"],
+    catchup=False,
+) as dag:
+
+    date_filter = "{{ prev_execution_date_success or '2020-12-31' }}"
+
+    t1 = DockerOperator(
+        task_id="road_conditions_socrata",
+        image=docker_image,
+        api_version="auto",
+        auto_remove=True,
+        command=f'./atd-road-conditions/socrata.py -d "{date_filter}"',
+        #docker_url="tcp://localhost:2376",
+        #network_mode="bridge",
+        environment=env_vars,
+        #tty=True,
+    )
+
+    t1
+
+if __name__ == "__main__":
+    dag.cli()

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -102,7 +102,7 @@ x-airflow-common:
 services:
 
   haproxy:
-    restart: always
+    restart: unless-stopped
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
@@ -120,7 +120,7 @@ services:
       - webhook
 
   webhook:
-    restart: always
+    restart: unless-stopped
     build: ./webhook
     environment:
       <<: *airflow-common-env
@@ -132,7 +132,7 @@ services:
       - ${AIRFLOW_PROJ_DIR:-.}/private_key_for_github:/opt/private_key_for_github
 
   weather:
-    restart: always
+    restart: unless-stopped
     image: httpd:2.4
     volumes:
       - ${AIRFLOW_PROJ_DIR:-.}/weather:/usr/local/apache2/htdocs
@@ -150,7 +150,7 @@ services:
       interval: 10s
       retries: 5
       start_period: 5s
-    restart: always
+    restart: unless-stopped
 
   redis:
     image: redis:latest
@@ -162,7 +162,7 @@ services:
       timeout: 30s
       retries: 50
       start_period: 30s
-    restart: always
+    restart: unless-stopped
 
   airflow-webserver:
     <<: *airflow-common
@@ -173,7 +173,7 @@ services:
       timeout: 10s
       retries: 5
       start_period: 30s
-    restart: always
+    restart: unless-stopped
     depends_on:
       <<: *airflow-common-depends-on
       airflow-init:
@@ -188,7 +188,7 @@ services:
       timeout: 10s
       retries: 5
       start_period: 30s
-    restart: always
+    restart: unless-stopped
     depends_on:
       <<: *airflow-common-depends-on
       airflow-init:
@@ -210,7 +210,7 @@ services:
       # Required to handle warm shutdown of the celery workers properly
       # See https://airflow.apache.org/docs/docker-stack/entrypoint.html#signal-propagation
       DUMB_INIT_SETSID: "0"
-    restart: always
+    restart: unless-stopped
     depends_on:
       <<: *airflow-common-depends-on
       airflow-init:
@@ -225,7 +225,7 @@ services:
       timeout: 10s
       retries: 5
       start_period: 30s
-    restart: always
+    restart: unless-stopped
     depends_on:
       <<: *airflow-common-depends-on
       airflow-init:
@@ -331,7 +331,7 @@ services:
       timeout: 10s
       retries: 5
       start_period: 30s
-    restart: always
+    restart: unless-stopped
     depends_on:
       <<: *airflow-common-depends-on
       airflow-init:


### PR DESCRIPTION
## Intent: Install a legacy DAG
This installs a 3 year old DAG, still in use today on ATD airflow.
* One line must be commented out, as the local and production stack both use the `/var/run/docker.sock` file to communicate with docker, not over HTTP

## Expected Outcome
* This DAG runs, but fails, because I am providing it with nonsense credentials. I can't/won't install ATD secrets in a non-ATD system.

* ✅ Orchestration & execution of flow
* ❌ Flow success running on `airflow.fyi`